### PR TITLE
cit_petsc: allow empty PETSC_ARCH; means prefix install

### DIFF
--- a/cit_petsc.m4
+++ b/cit_petsc.m4
@@ -37,7 +37,9 @@ AC_MSG_RESULT([$PETSC_DIR])
 
 AC_MSG_CHECKING([for PETSc arch])
 if test -z "$PETSC_ARCH"; then
-    if test -d "$PETSC_DIR/conf"; then
+    if test -d "$PETSC_DIR/lib/petsc/conf"; then
+        AC_MSG_RESULT(no)
+    elif test -d "$PETSC_DIR/conf"; then
         # new config layout; no default config (?)
         AC_MSG_RESULT(no)
         m4_default([$3], [AC_MSG_ERROR([set PETSC_ARCH])])


### PR DESCRIPTION
It looks like someone attempted to implement this (in the logic further down in the file), but didn't test. I don't know if this is how you'd like it to be done, but this gets a build going for me.