### PR TITLE
Add macros for testing for Proj v6.x header file and library.

### DIFF
--- a/cit_proj4.m4
+++ b/cit_proj4.m4
@@ -27,4 +27,26 @@ AC_DEFUN([CIT_PROJ4_LIB], [
 ])dnl CIT_PROJ4_LIB
 
 
+# ----------------------------------------------------------------------
+# CIT_PROJ6_HEADER
+# ----------------------------------------------------------------------
+AC_DEFUN([CIT_PROJ6_HEADER], [
+  AC_LANG(C)
+  AC_CHECK_HEADER([proj.h], [], [
+    AC_MSG_ERROR([Proj header (v6.x or later) not found; try CPPFLAGS="-I<Proj include dir>"])
+  ])dnl
+])dnl CIT_PROJ6_HEADER
+
+
+# ----------------------------------------------------------------------
+# CIT_PROJ6_LIB
+# ----------------------------------------------------------------------
+AC_DEFUN([CIT_PROJ6_LIB], [
+  AC_LANG(C)
+  AC_CHECK_LIB(proj, proj_create_crs_to_crs, [],[
+    AC_MSG_ERROR([Proj library (v6.x or later) not found; try LDFLAGS="-L<Proj lib dir>"])
+  ])dnl
+])dnl CIT_PROJ6_LIB
+
+
 dnl end of file


### PR DESCRIPTION
In testing for Proj v4.x, we used the `proj_api.h` header file and the `pj_init_plus()` function. These are deprecated.

To test for Proj v6.x, we test `proj.h` via `CIT_PROJ6_HEADER` and `proj_create_crs_to_crs()` via CIT_PROJ6_LIB.