### PR TITLE
Allow package specific INCLUDES and LDFLAGS. Add pcre and sqlite checks.

### DIFF
--- a/cit_cppunit.m4
+++ b/cit_cppunit.m4
@@ -9,11 +9,14 @@
 # CIT_CPPUNIT_HEADER
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_CPPUNIT_HEADER], [
+  cit_save_cppflags=$CPPFLAGS
+  CPPFLAGS="$CPPFLAGS $CPPUNIT_INCLUDES"
   AC_LANG(C++)
   AC_REQUIRE_CPP
   AC_CHECK_HEADER([cppunit/TestRunner.h], [], [
-    AC_MSG_ERROR([CppUnit header not found; try CPPFLAGS="-I<CppUnit include dir>"])
+    AC_MSG_ERROR([CppUnit header not found; try --with-cppunit-incdir=<CppUnit include dir>])
   ])dnl
+  CPPFLAGS=$cit_save_cppflags
 ])dnl CIT_CPPUNIT_HEADER
 
 
@@ -21,17 +24,26 @@ AC_DEFUN([CIT_CPPUNIT_HEADER], [
 # CIT_CPPUNIT_LIB
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_CPPUNIT_LIB], [
+  cit_save_cppflags=$CPPFLAGS
+  cit_save_ldflags=$LDFLAGS
+  cit_save_libs=$LIBS
+  CPPFLAGS="$CPPFLAGS $CPPUNIT_INCLUDES"
+  LDFLAGS="$LDFLAGS $CPPUNIT_LDFLAGS"
+  LIBS="-lcppunit"
   AC_LANG(C++)
   AC_REQUIRE_CPP
   AC_MSG_CHECKING([for CppUnit::TestRunner in -lcppunit])
-  AC_COMPILE_IFELSE(
+  AC_LINK_IFELSE(
     [AC_LANG_PROGRAM([[#include <cppunit/TestRunner.h>]],
 	             [[CppUnit::TestRunner runner;]])],
     [AC_MSG_RESULT(yes)],
     [AC_MSG_RESULT(no)
-     AC_MSG_ERROR([CppUnit library not found; try LDFLAGS="-L<CppUnit lib dir>"])
-  ])dnl
-])dnl CIT_CPPUNIT
+     AC_MSG_ERROR([CppUnit library not found; try --with-cppunit-libdir=<CppUnit lib dir>])
+    ])
+  CPPFLAGS=$cit_save_cppflags
+  LDFLAGS=$cit_save_ldflags
+  LIBS=$cit_save_libs
+])dnl CIT_CPPUNIT_LIB
 
 
 dnl end of file

--- a/cit_hdf5.m4
+++ b/cit_hdf5.m4
@@ -8,11 +8,14 @@
 # CIT_HDF5_HEADER
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_HDF5_HEADER], [
-  AC_LANG(C++)
+  cit_save_cppflags=$CPPFLAGS
+  CPPFLAGS="$CPPFLAGS $HDF5_INCLUDES"
+  AC_LANG(C)
   AC_REQUIRE_CPP
   AC_CHECK_HEADER([hdf5.h], [], [
-    AC_MSG_ERROR([HDF5 header not found; try CPPFLAGS="-I<hdf5 include dir>"])
+    AC_MSG_ERROR([HDF5 header not found; try --with-hdf5-incdir=<hdf5 include dir>])
   ])dnl
+  CPPFLAGS=$cit_save_cppflags
 ])dnl CIT_HDF5_HEADER
 
 
@@ -20,17 +23,19 @@ AC_DEFUN([CIT_HDF5_HEADER], [
 # CIT_NETCDF_LIB
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_HDF5_LIB], [
-  AC_LANG(C++)
+  cit_save_cppflags=$CPPFLAGS
+  cit_save_ldflags=$LDFLAGS
+  cit_save_libs=$LIBS
+  CPPFLAGS="$CPPFLAGS $HDF5_INCLUDES"
+  LDFLAGS="$LDFLAGS $HDF5_LDFLAGS"
+  AC_LANG(C)
   AC_REQUIRE_CPP
-  AC_MSG_CHECKING([for H5Fopen in -lhdf5])
-  AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM([[#include <hdf5.h>]],
-	             [[H5Fopen("test.h5", H5F_ACC_TRUNC, H5P_DEFAULT);]])],
-    [AC_MSG_RESULT(yes)],
-    [AC_MSG_RESULT(no)
-     AC_MSG_ERROR([hdf5 library not found; try LDFLAGS="-L<hdf5 lib dir>"])
-    ])dnl
-  ]))
+  AC_CHECK_LIB(hdf5, H5Fopen, [],[
+    AC_MSG_ERROR([HDF5 library not found; try --with-hdf5-libdir=<HDF5 lib dir>])
+  ])dnl
+  CPPFLAGS=$cit_save_cppflags
+  LDFLAGS=$cit_save_ldflags
+  LIBS=$cit_save_libs
 ])dnl CIT_HDF5_LIB
 
 
@@ -38,12 +43,20 @@ AC_DEFUN([CIT_HDF5_LIB], [
 # CIT_NETCDF_LIB_PARALLEL
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_HDF5_LIB_PARALLEL], [
-  AC_LANG(C++)
+  cit_save_cppflags=$CPPFLAGS
+  cit_save_ldflags=$LDFLAGS
+  cit_save_libs=$LIBS
+  CPPFLAGS="$CPPFLAGS $HDF5_INCLUDES"
+  LDFLAGS="$LDFLAGS $HDF5_LDFLAGS"
+  AC_LANG(C)
   AC_REQUIRE_CPP
-  AC_SEARCH_LIBS([H5Pset_dxpl_mpio], [hdf5], [], [
+  AC_CHECK_LIB(hdf5, H5Pset_dxpl_mpio, [],[
     AC_MSG_WARN([parallel HDF5 library not found; DO NOT attempt to use HDF5 in parallel OR configure HDF5 with '--enable-parallel'])
   ])
-])dnl CIT_HDF5_LIB
+  CPPFLAGS=$cit_save_cppflags
+  LDFLAGS=$cit_save_ldflags
+  LIBS=$cit_save_libs
+])dnl CIT_HDF5_LIB_PARALLEL
 
 
 dnl end of file

--- a/cit_pcre.m4
+++ b/cit_pcre.m4
@@ -2,43 +2,43 @@
 
 
 # ======================================================================
-# Autoconf macros for netcdf.
+# Autoconf macros for pcre.
 # ======================================================================
 
 # ----------------------------------------------------------------------
-# CIT_NETCDF_HEADER
+# CIT_PCRE_HEADER
 # ----------------------------------------------------------------------
-AC_DEFUN([CIT_NETCDF_HEADER], [
+AC_DEFUN([CIT_PCRE_HEADER], [
   cit_save_cppflags=$CPPFLAGS
-  CPPFLAGS="$CPPFLAGS $NETCDF_INCLUDES"
-  AC_LANG(C)
+  CPPFLAGS="$CPPFLAGS $PCRE_INCLUDES"
+  AC_LANG(C++)
   AC_REQUIRE_CPP
-  AC_CHECK_HEADER([netcdf.h], [], [
-    AC_MSG_ERROR([NetCDF header not found; try --with-netcdf-incdir=<NetCDF include dir>])
+  AC_CHECK_HEADER([pcre.h], [], [
+    AC_MSG_ERROR([pcre header not found; try --with-pcre-incdir=<pcre include dir>])
   ])dnl
   CPPFLAGS=$cit_save_cppflags
-])dnl CIT_NETCDF_HEADER
+])dnl CIT_PCRE_HEADER
 
 
 # ----------------------------------------------------------------------
-# CIT_NETCDF_LIB
+# CIT_PCRE_LIB
 # ----------------------------------------------------------------------
-AC_DEFUN([CIT_NETCDF_LIB], [
+AC_DEFUN([CIT_PCRE_LIB], [
   cit_save_cppflags=$CPPFLAGS
   cit_save_ldflags=$LDFLAGS
   cit_save_libs=$LIBS
-  CPPFLAGS="$CPPFLAGS $NETCDF_INCLUDES"
-  LDFLAGS="LDFLAGS $NETCDF_LDFLAGS"
-  AC_LANG(C)
+  CPPFLAGS="$CPPFLAGS $PCRE_INCLUDES"
+  LDFLAGS="$LDFLAGS $PCRE_LDFLAGS"
+  AC_LANG(C++)
   AC_REQUIRE_CPP
-  AC_MSG_CHECKING([for nc_open in -lnetcdf])
-  AC_CHECK_LIB(netcdf, nc_open, [],[
-    AC_MSG_ERROR([NetCDF library not found; try --with-netcdf-libdir=<NetCDF lib dir>])
+  AC_MSG_CHECKING([for real_pcre in -lpcre])
+  AC_CHECK_LIB(pcre, pcre2_compile, [],[
+    AC_MSG_ERROR([pcre library not found; try --with-pcre-libdir=<pcre lib dir>])
   ])dnl
   CPPFLAGS=$cit_save_cppflags
   LDFLAGS=$cit_save_ldflags
   LIBS=$cit_save_libs
-])dnl CIT_NETCDF_LIB
+])dnl CIT_PCRE
 
 
 dnl end of file

--- a/cit_proj4.m4
+++ b/cit_proj4.m4
@@ -9,10 +9,13 @@
 # CIT_PROJ4_HEADER
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_PROJ4_HEADER], [
+  cit_save_cppflags=$CPPFLAGS
+  CPPFLAGS="$CPPFLAGS $PROJ_INCLUDES"
   AC_LANG(C)
   AC_CHECK_HEADER([proj_api.h], [], [
-    AC_MSG_ERROR([Proj4 header not found; try CPPFLAGS="-I<Proj4 include dir>"])
+    AC_MSG_ERROR([Proj header not found; try --with-proj-incdir=<Proj include dir>])
   ])dnl
+  CPPFLAGS=$cit_save_cppflags
 ])dnl CIT_PROJ4_HEADER
 
 
@@ -20,10 +23,18 @@ AC_DEFUN([CIT_PROJ4_HEADER], [
 # CIT_PROJ4_LIB
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_PROJ4_LIB], [
+  cit_save_cppflags=$CPPFLAGS
+  cit_save_ldflags=$LDFLAGS
+  cit_save_libs=$LIBS
+  CPPFLAGS="$CPPFLAGS $PROJ_INCLUDES"
+  LDFLAGS="$LDFLAGS $PROJ_LDFLAGS"
   AC_LANG(C)
   AC_CHECK_LIB(proj, pj_init_plus, [],[
-    AC_MSG_ERROR([Proj4 library not found; try LDFLAGS="-L<Proj4 lib dir>"])
+    AC_MSG_ERROR([Proj library not found; try --with-proj-libdir=<Proj lib dir>])
   ])dnl
+  CPPFLAGS=$cit_save_cppflags
+  LDFLAGS=$cit_save_ldflags
+  LIBS=$cit_save_libs
 ])dnl CIT_PROJ4_LIB
 
 
@@ -31,10 +42,13 @@ AC_DEFUN([CIT_PROJ4_LIB], [
 # CIT_PROJ6_HEADER
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_PROJ6_HEADER], [
+  cit_save_cppflags=$CPPFLAGS
+  CPPFLAGS="$CPPFLAGS $PROJ_INCLUDES"
   AC_LANG(C)
   AC_CHECK_HEADER([proj.h], [], [
-    AC_MSG_ERROR([Proj header (v6.x or later) not found; try CPPFLAGS="-I<Proj include dir>"])
+    AC_MSG_ERROR([Proj header (v6.x or later) not found; try --with-proj-incdir=<Proj include dir>])
   ])dnl
+  CPPFLAGS=$cit_save_cppflags
 ])dnl CIT_PROJ6_HEADER
 
 
@@ -42,10 +56,18 @@ AC_DEFUN([CIT_PROJ6_HEADER], [
 # CIT_PROJ6_LIB
 # ----------------------------------------------------------------------
 AC_DEFUN([CIT_PROJ6_LIB], [
+  cit_save_cppflags=$CPPFLAGS
+  cit_save_ldflags=$LDFLAGS
+  cit_save_libs=$LIBS
+  CPPFLAGS="$CPPFLAGS $PROJ_INCLUDES"
+  LDFLAGS="$LDFLAGS $PROJ_LDFLAGS"
   AC_LANG(C)
   AC_CHECK_LIB(proj, proj_create_crs_to_crs, [],[
-    AC_MSG_ERROR([Proj library (v6.x or later) not found; try LDFLAGS="-L<Proj lib dir>"])
+    AC_MSG_ERROR([Proj library (v6.x or later) not found; try --with-proj-libdir=<Proj lib dir>])
   ])dnl
+  CPPFLAGS=$cit_save_cppflags
+  LDFLAGS=$cit_save_ldflags
+  LIBS=$cit_save_libs
 ])dnl CIT_PROJ6_LIB
 
 

--- a/cit_sqlite.m4
+++ b/cit_sqlite.m4
@@ -2,43 +2,42 @@
 
 
 # ======================================================================
-# Autoconf macros for netcdf.
+# Autoconf macros for sqlite3.
 # ======================================================================
 
 # ----------------------------------------------------------------------
-# CIT_NETCDF_HEADER
+# CIT_SQLITE_HEADER
 # ----------------------------------------------------------------------
-AC_DEFUN([CIT_NETCDF_HEADER], [
+AC_DEFUN([CIT_SQLITE3_HEADER], [
   cit_save_cppflags=$CPPFLAGS
-  CPPFLAGS="$CPPFLAGS $NETCDF_INCLUDES"
-  AC_LANG(C)
+  CPPFLAGS="$CPPFLAGS $SQLITE3_INCLUDES"
+  AC_LANG(C++)
   AC_REQUIRE_CPP
-  AC_CHECK_HEADER([netcdf.h], [], [
-    AC_MSG_ERROR([NetCDF header not found; try --with-netcdf-incdir=<NetCDF include dir>])
+  AC_CHECK_HEADER([sqlite3.h], [], [
+    AC_MSG_ERROR([sqlite3 header not found; try --with-sqlite-incdir=<sqlite3 include dir>"])
   ])dnl
   CPPFLAGS=$cit_save_cppflags
-])dnl CIT_NETCDF_HEADER
+])dnl CIT_SQLITE3_HEADER
 
 
 # ----------------------------------------------------------------------
-# CIT_NETCDF_LIB
+# CIT_SQLITE_LIB
 # ----------------------------------------------------------------------
-AC_DEFUN([CIT_NETCDF_LIB], [
-  cit_save_cppflags=$CPPFLAGS
-  cit_save_ldflags=$LDFLAGS
+AC_DEFUN([CIT_SQLITE3_LIB], [
+  cit_save_CPPFLAGS=$CPPFLAGS
+  cit_save_LDFLAGS=$LDFLAGS
   cit_save_libs=$LIBS
-  CPPFLAGS="$CPPFLAGS $NETCDF_INCLUDES"
-  LDFLAGS="LDFLAGS $NETCDF_LDFLAGS"
-  AC_LANG(C)
+  CPPFLAGS="$CPPFLAGS $SQLITE3_INCLUDES"
+  LDFLAGS="$LDFLAGS $SQLITE3_LDFLAGS"
+  AC_LANG(C++)
   AC_REQUIRE_CPP
-  AC_MSG_CHECKING([for nc_open in -lnetcdf])
-  AC_CHECK_LIB(netcdf, nc_open, [],[
-    AC_MSG_ERROR([NetCDF library not found; try --with-netcdf-libdir=<NetCDF lib dir>])
+  AC_CHECK_LIB(sqlite3, sqlite3_open, [],[
+    AC_MSG_ERROR([sqlite3 library not found; try --with-sqlite-libdir=<sqlite3 lib dir>])
   ])dnl
   CPPFLAGS=$cit_save_cppflags
   LDFLAGS=$cit_save_ldflags
   LIBS=$cit_save_libs
-])dnl CIT_NETCDF_LIB
+])dnl CIT_SQLITE3_LIB
 
 
 dnl end of file


### PR DESCRIPTION
Allow `configure.ac` files to create package specific `INCLUDES` and `LDFLAGS` variables (e.g., `HDF5_INCLUDES` and `HDF5_LDFLAGS`) from specification of include and lib directories as configure arguments (e.g., `--with-hdf5-incdir=PATH_TO_HEADER_FILES` and `--with-hdf5-libdir=PATH_TO_LIB_FILES`).

This allows configure to find header files and libraries using either `CPPFLAGS`/`LDFLAGS` environment variables -or- from user specification of specific directories. Configuration of dependencies can make use of the more specific directories when necessary.

Add header and library checks for PCRE and Sqlite3.