### PR TITLE
Change 'compile' to 'link' in spatialdata library check.

### DIFF
--- a/cit_spatialdata.m4
+++ b/cit_spatialdata.m4
@@ -23,7 +23,7 @@ AC_DEFUN([CIT_SPATIALDATA_LIB], [
   AC_LANG(C++)
   AC_REQUIRE_CPP
   AC_MSG_CHECKING([for SimpleDB in -lspatialdata])
-  AC_COMPILE_IFELSE(
+  AC_LINK_IFELSE(
     [AC_LANG_PROGRAM([[#include <spatialdata/spatialdb/SpatialDB.hh>]
                       [#include <spatialdata/spatialdb/SimpleDB.hh>]],
                      [[spatialdata::spatialdb::SimpleDB db;]])],


### PR DESCRIPTION
The check for the presence of the spatialdata library was simply a compile test. This should be a link test.